### PR TITLE
v.1.3.1 Release -- Version Fix

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ type: software
 license: Apache-2.0
 repository-code: 'https://github.com/MannLabs/OmicLearn/'
 url: 'http://omiclearn.org'
-version: 1.3
+version: 1.3.1
 preferred-citation:
   title: "Transparent Exploration of Machine Learning for Biomarker Discovery from Proteomics and Omics Data"
   type: article

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ![OmicLearn Tests](https://github.com/MannLabs/OmicLearn/workflows/OmicLearn%20Tests/badge.svg)
 ![OmicLearn Python Badges](https://img.shields.io/badge/Tested_with_Python-3.9-blue)
-![OmicLearn Version](https://img.shields.io/badge/Release-v1.3-orange)
+![OmicLearn Version](https://img.shields.io/badge/Release-v1.3.1-orange)
 ![OmicLearn Release](https://img.shields.io/badge/Release%20Date-October%202022-green)
 ![OmicLearn License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)
 

--- a/docs/source/README.md
+++ b/docs/source/README.md
@@ -5,7 +5,7 @@
 
 ![OmicLearn Tests](https://github.com/MannLabs/OmicLearn/workflows/OmicLearn%20Tests/badge.svg)
 ![OmicLearn Python Badges](https://img.shields.io/badge/Tested_with_Python-3.9-blue)
-![OmicLearn Version](https://img.shields.io/badge/Release-v1.3-orange)
+![OmicLearn Version](https://img.shields.io/badge/Release-v1.3.1-orange)
 ![OmicLearn Release](https://img.shields.io/badge/Release%20Date-July%202022-green)
 ![OmicLearn License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)
 

--- a/docs/source/VERSION-HISTORY.md
+++ b/docs/source/VERSION-HISTORY.md
@@ -2,11 +2,23 @@
 
 On this page, you might find the list of the previous releases of **OmicLearn** and the notes and significant changes made within the versions.
 
+### - `v1.3.1`
+
+> 📅  April 2023
+>
+> This is the latest release of **OmicLearn**.
+>
+> **Updates in this release:**
+>
+> - [x] Now, you can add **Additional features** (which starts with leading '_') in addition to proteins/gene identifiers in `Manual feature selection` section.
+>
+
+
+
 ### - `v1.3`
 
 > 📅  October 2022
 >
-> This is the latest release of **OmicLearn**.
 >
 > **Updates in this release:**
 >

--- a/docs/source/VERSION-HISTORY.md
+++ b/docs/source/VERSION-HISTORY.md
@@ -10,9 +10,8 @@ On this page, you might find the list of the previous releases of **OmicLearn** 
 >
 > **Updates in this release:**
 >
-> - [x] Now, you can add **Additional features** (which starts with leading '_') in addition to proteins/gene identifiers in `Manual feature selection` section.
+> - [x] Minor fix has been done.
 >
-
 
 
 ### - `v1.3`

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,12 +17,12 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'OmicLearn'
-copyright = '2022, Furkan Torun, Maximilian Strauss'
-author = 'Furkan Torun, Maximilian Strauss'
+project = "OmicLearn"
+copyright = "2022, Furkan Torun, Maximilian Strauss"
+author = "Furkan Torun, Maximilian Strauss"
 
 # The full version, including alpha/beta/rc tags
-release = '1.3'
+release = "1.3.1"
 
 
 # -- General configuration ---------------------------------------------------
@@ -30,10 +30,10 @@ release = '1.3'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['myst_parser']
+extensions = ["myst_parser"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -46,9 +46,9 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/omiclearn/__init__.py
+++ b/omiclearn/__init__.py
@@ -2,7 +2,7 @@
 
 
 __project__ = "omiclearn"
-__version__ = "1.3"
+__version__ = "1.3.1"
 __license__ = "Apache"
 __description__ = "Transparent exploration of machine learning for biomarker discovery from proteomics and omics data"
 __author__ = "MannLabs"

--- a/omiclearn/utils/ui_helper.py
+++ b/omiclearn/utils/ui_helper.py
@@ -492,7 +492,7 @@ def get_system_report():
     Returns the package versions
     """
     report = {}
-    report["omic_learn_version"] = "v1.3"
+    report["omic_learn_version"] = "v1.3.1"
     report["python_version"] = sys.version[:5]
     report["pandas_version"] = pd.__version__
     report["numpy_version"] = np.version.version

--- a/reqs.txt
+++ b/reqs.txt
@@ -1,12 +1,12 @@
 streamlit==1.10.0
-pandas
-numpy
-scikit-learn
+pandas==1.5.0
+numpy==1.23.3
+scikit-learn==1.1.2
 openpyxl==3.0.10
 plotly==5.9.0
 kaleido==0.2.1
 XlsxWriter==3.0.3
 watchdog==2.1.9
-xgboost
+xgboost==1.6.2
 protobuf==3.20
-myst_parser
+myst_parser==0.18.1


### PR DESCRIPTION
Hi @straussmaximilian ,
I realized we did not lock the versions for several packages in `reqs.txt`.
Normally, it is not a problem in `one-click` installer since they are bundled with the versions.
However, in the future, this might cause issues.


Important point is that currently, the web version (omiclearn.com) always installs the latest version of the packages whose versions were not locked and this might cause some mismatch in the future.

Here, I checked the summary text for the versions in `v.1.3` one-click Mac-OS installer | https://github.com/MannLabs/OmicLearn/releases/download/v.1.3.0/omiclearn_gui_installer_macos.pkg:

<img width="730" alt="Screenshot 2023-03-30 at 15 06 52" src="https://user-images.githubusercontent.com/49681382/228845445-c6f96319-6144-4c76-aff1-e0647ab0e0ca.png">

I also checked the package contents after installing on the file system to get the versions of other packages such as `xgboost` and `myst_parser`.


Best,
Furkan
