### PR TITLE
Fix docs links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Ready to contribute? Here's how to set up `OmicLearn` for local development.
     git clone https://github.com/MannLabs/OmicLearn.git
     ```
 
-3.  Follow the installation instructions in the [Python Installation](https://OmicLearn.readthedocs.io/en/latest/README.html#python-installation) page for installing `OmicLearn` own environment.
+3.  Follow the installation instructions in the [Python Installation](https://omiclearn.readthedocs.io/en/latest/index.html#local-installation) page for installing `OmicLearn` own environment.
 
 4.  Create a branch for local development:
 

--- a/docs/source/VERSION-HISTORY.md
+++ b/docs/source/VERSION-HISTORY.md
@@ -14,7 +14,8 @@ On this page, you might find the list of the previous releases of **OmicLearn** 
 > - [x] `New Feature`: The section "Summary text" now has "Download as *.txt" button so that you can get it via a single click to save for your paper.
 > - [x] `New Feature`: The section "Additional features" supports file upload.
 > - [x] `Change`: The files to be uploaded in the section "Exclude features" now does not need to include header/title row at the top of the file. [See details here.](./USING.md)
-> - [x]: `Change`: The summary text is now updated and grammar mistake is fixed.
+> - [x] `Change`: The summary text is now updated and grammar mistake is fixed.
+> - [x] Documentation pages and theme are updated.
 > - [X] The Streamlit and other packages/libraries are upgraded to their new versions.
 > - [x] Several improvements on UI and UX sides have been made.
 > - [x] OmicLearn is now faster!

--- a/omiclearn/utils/ui_components.py
+++ b/omiclearn/utils/ui_components.py
@@ -337,7 +337,7 @@ def generate_sidebar_elements(state, icon, report, record_widgets):
         caption="OmicLearn " + report["OmicLearn_version"],
     )
     st.sidebar.markdown(
-        "# [Options](https://OmicLearn.readthedocs.io/en/latest//METHODS.html)"
+        "# [Options](https://OmicLearn.readthedocs.io/en/latest/METHODS.html)"
     )
 
     # Random State

--- a/omiclearn/utils/ui_texts.py
+++ b/omiclearn/utils/ui_texts.py
@@ -5,7 +5,7 @@ DISCLAIMER_TEXT = """
 **⚠️ Warning:** It is possible to get artificially high or low performance because of technical and biological artifacts in the data.
 While OmicLearn has the functionality to perform basic exploratory data analysis (EDA) such as PCA, 
 it is not meant to substitute throughout data exploration but rather add a machine learning layer.
-Please check our [recommendations](https://OmicLearn.readthedocs.io/en/latest/recommendations.html) 
+Please check our [recommendations](https://OmicLearn.readthedocs.io/en/latest/RECOMMENDATIONS.html) 
 page for potential pitfalls and interpret performance metrics accordingly.
 
 **Note:** By uploading a file, you agree to our [Apache License](https://github.com/MannLabs/OmicLearn/blob/master/LICENSE.txt).
@@ -25,8 +25,7 @@ FILE_UPLOAD_TEXT = """Maximum size 200 MB. One row per sample, one column per fe
 """
 
 ALZHEIMER_CITATION_TEXT = """
-**This dataset was retrieved from the following paper and the code for parsing is available at
-[GitHub](https://github.com/MannLabs/OmicLearn/blob/master/data/Alzheimer_paper.ipynb):**\n
+**This dataset was retrieved from the following paper:**\n
 Bader, J., Geyer, P., Müller, J., Strauss, M., Koch, M., & Leypoldt, F. et al. (2020).
 Proteome profiling in cerebrospinal fluid reveals novel biomarkers of Alzheimer's disease.
 Molecular Systems Biology, 16(6). doi: [10.15252/msb.20199356](http://doi.org/10.15252/msb.20199356)
@@ -67,7 +66,7 @@ MANUALLY_SELECT_FEATURES_TEXT = "Manually select a subset of features. If only t
 "`Feature selection` method to `None`. "
 "Otherwise, feature selection will be applied, and only a subset of the manually selected features is used. "
 "Be aware of potential overfitting when manually selecting features and "
-"check [recommendations](https://OmicLearn.readthedocs.io/en/latest/recommendations.html) page for potential pitfalls."
+"check [recommendations](https://OmicLearn.readthedocs.io/en/latest/RECOMMENDATIONS.html) page for potential pitfalls."
 
 
 RESULTS_TABLE_INFO = """
@@ -90,6 +89,6 @@ RUNNING_INFO_TEXT = """
 - Using a total of **{LEN_STATE_FEATURES}** features.
 - ⚠️ **Warning:** OmicLearn is intended to be an exploratory tool to assess the performance of algorithms,
     rather than providing a classification model for production. 
-    Please check our [recommendations](https://OmicLearn.readthedocs.io/en/latest/recommendations.html)
+    Please check our [recommendations](https://OmicLearn.readthedocs.io/en/latest/RECOMMENDATIONS.html)
     page for potential pitfalls and interpret performance metrics accordingly.
 """


### PR DESCRIPTION
Update in this PR:

- Fix the hyperlinks to docs in the docs/code/markdowns